### PR TITLE
fix(ci): skip Anthropic secret sync when not configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,14 +191,19 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Sync secrets to baca-api
-        if: ${{ secrets.ANTHROPICAPI != '' }}
         run: |
-          az containerapp secret set -n baca-api -g ovcina \
-            --secrets "anthropic-key=${{ secrets.ANTHROPICAPI }}" \
-            --output none
-          az containerapp update -n baca-api -g ovcina \
-            --set-env-vars "Anthropic__ApiKey=secretref:anthropic-key" \
-            --output none
+          if [ -n "$ANTHROPIC_KEY" ]; then
+            az containerapp secret set -n baca-api -g ovcina \
+              --secrets "anthropic-key=$ANTHROPIC_KEY" \
+              --output none
+            az containerapp update -n baca-api -g ovcina \
+              --set-env-vars "Anthropic__ApiKey=secretref:anthropic-key" \
+              --output none
+          else
+            echo "ANTHROPICAPI secret not configured, skipping"
+          fi
+        env:
+          ANTHROPIC_KEY: ${{ secrets.ANTHROPICAPI }}
 
       - name: Deploy backend
         uses: azure/container-apps-deploy-action@v2


### PR DESCRIPTION
## Summary
- Skip the `az containerapp secret set` step when `ANTHROPICAPI` secret is not configured
- Prevents deploy failure when the secret hasn't been added to GitHub yet

## Test plan
- [ ] Deploy job should skip the secret sync step and proceed with deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)