### PR TITLE
fix: user creation fails when email send errors

### DIFF
--- a/backend/Baca.Api/Endpoints/UserEndpoints.cs
+++ b/backend/Baca.Api/Endpoints/UserEndpoints.cs
@@ -107,7 +107,15 @@ public static class UserEndpoints
         dbContext.Users.Add(user);
         await dbContext.SaveChangesAsync(ct);
 
-        await emailService.SendMagicLinkAsync(email, user.Name, token.Token, ct);
+        try
+        {
+            await emailService.SendMagicLinkAsync(email, user.Name, token.Token, ct);
+        }
+        catch
+        {
+            // User is already saved — don't fail the request if email sending fails.
+            // Admin can resend the link later.
+        }
 
         await dbContext.Entry(user)
             .Reference(createdUser => createdUser.GameRole)

--- a/frontend/src/components/admin/UserManagement.tsx
+++ b/frontend/src/components/admin/UserManagement.tsx
@@ -92,8 +92,9 @@ export default function UserManagement() {
       setUserList((prev) => [...prev, newUser]);
       setShowForm(false);
       setMessage({ text: 'Uživatel přidán', type: 'success' });
-    } catch {
-      setMessage({ text: 'Chyba při přidávání uživatele', type: 'error' });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Chyba při přidávání uživatele';
+      setMessage({ text: msg, type: 'error' });
     }
   };
 


### PR DESCRIPTION
## Summary
- `CreateUserAsync` saved user to DB then sent welcome email — if email threw, the request returned 500 even though the user was already persisted
- Next attempt with same email showed "already exists" because user WAS created
- Fix: wrap email send in try/catch, admin can resend link later
- Frontend now surfaces actual backend error messages instead of generic "Chyba při přidávání uživatele"

Closes #19

## Test plan
- [ ] Create user with valid data — should succeed
- [ ] Create user with duplicate email — should show "Uživatel se stejným e-mailem už existuje"
- [ ] If email service is down, user creation still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)