### PR TITLE
fix: rename Board to Tabule, fix Anthropic key deployment (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,21 +190,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Sync secrets to baca-api
-        run: |
-          if [ -n "$ANTHROPIC_KEY" ]; then
-            az containerapp secret set -n baca-api -g ovcina \
-              --secrets "anthropic-key=$ANTHROPIC_KEY" \
-              --output none
-            az containerapp update -n baca-api -g ovcina \
-              --set-env-vars "Anthropic__ApiKey=secretref:anthropic-key" \
-              --output none
-          else
-            echo "ANTHROPICAPI secret not configured, skipping"
-          fi
-        env:
-          ANTHROPIC_KEY: ${{ secrets.ANTHROPHICAPI }}
-
       - name: Deploy backend
         uses: azure/container-apps-deploy-action@v2
         with:
@@ -218,3 +203,18 @@ jobs:
           containerAppName: baca-web
           resourceGroup: ovcina
           imageToDeploy: ovcinaacr.azurecr.io/baca-web:${{ github.sha }}
+
+      - name: Sync secrets to baca-api
+        run: |
+          if [ -n "$ANTHROPIC_KEY" ]; then
+            az containerapp secret set -n baca-api -g ovcina \
+              --secrets "anthropic-key=$ANTHROPIC_KEY" \
+              --output none
+            az containerapp update -n baca-api -g ovcina \
+              --set-env-vars "Anthropic__ApiKey=secretref:anthropic-key" \
+              --output none
+          else
+            echo "ANTHROPHICAPI secret not configured, skipping"
+          fi
+        env:
+          ANTHROPIC_KEY: ${{ secrets.ANTHROPHICAPI }}

--- a/frontend/src/components/layout/BottomTabBar.tsx
+++ b/frontend/src/components/layout/BottomTabBar.tsx
@@ -14,7 +14,7 @@ export default function BottomTabBar() {
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
       </svg>
     ), badge: tasks.length },
-    { to: '/board', label: 'Board', icon: (
+    { to: '/board', label: 'Tabule', icon: (
       <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
       </svg>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -39,7 +39,7 @@ export default function Header() {
               Přehled
             </NavLink>
             <NavLink to="/board" className={({ isActive }) => `text-sm font-medium hover:text-green-200 transition-colors ${isActive ? 'text-white border-b-2 border-white' : 'text-green-100'}`}>
-              Board
+              Tabule
             </NavLink>
             <NavLink to="/board/user" className={({ isActive }) => `text-sm font-medium hover:text-green-200 transition-colors ${isActive ? 'text-white border-b-2 border-white' : 'text-green-100'}`}>
               Uživatelé

--- a/frontend/src/test/components/BottomTabBar.test.tsx
+++ b/frontend/src/test/components/BottomTabBar.test.tsx
@@ -27,7 +27,7 @@ describe('BottomTabBar', () => {
       </BrowserRouter>
     );
     expect(screen.getByText('Fokus')).toBeInTheDocument();
-    expect(screen.getByText('Board')).toBeInTheDocument();
+    expect(screen.getByText('Tabule')).toBeInTheDocument();
     expect(screen.getByText('Hlas')).toBeInTheDocument();
     expect(screen.getByText('Staty')).toBeInTheDocument();
   });

--- a/frontend/src/test/components/Header.test.tsx
+++ b/frontend/src/test/components/Header.test.tsx
@@ -37,7 +37,7 @@ describe('Header', () => {
       </BrowserRouter>
     );
     expect(screen.getByText('Přehled')).toBeInTheDocument();
-    expect(screen.getByText('Board')).toBeInTheDocument();
+    expect(screen.getByText('Tabule')).toBeInTheDocument();
   });
 
   it('renders task count badge', () => {


### PR DESCRIPTION
## Summary
- **#32** Rename "Board" to "Tabule" in header nav and mobile bottom tab bar
- **CI fix** Move Anthropic secret sync step to run AFTER container deploy, so the env var persists on the new revision (fixes bulk import failing with "Nepodařilo se zpracovat text")

## Test plan
- [ ] Verify "Tabule" label in header and bottom nav
- [ ] After deploy, verify bulk import processes text via Anthropic API

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)