### PR TITLE
fix: cold starts, AI error messages, Anthropic key name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,11 @@ jobs:
           resourceGroup: ovcina
           imageToDeploy: ovcinaacr.azurecr.io/baca-web:${{ github.sha }}
 
+      - name: Set min replicas to 1 (avoid cold starts)
+        run: |
+          az containerapp update -n baca-api -g ovcina --min-replicas 1 --output none
+          az containerapp update -n baca-web -g ovcina --min-replicas 1 --output none
+
       - name: Sync secrets to baca-api
         run: |
           if [ -n "$ANTHROPIC_KEY" ]; then
@@ -213,8 +218,9 @@ jobs:
             az containerapp update -n baca-api -g ovcina \
               --set-env-vars "Anthropic__ApiKey=secretref:anthropic-key" \
               --output none
+            echo "Anthropic key configured successfully"
           else
-            echo "ANTHROPHICAPI secret not configured, skipping"
+            echo "WARNING: ANTHROPIC_KEY secret not found in GitHub secrets"
           fi
         env:
-          ANTHROPIC_KEY: ${{ secrets.ANTHROPHICAPI }}
+          ANTHROPIC_KEY: ${{ secrets['ANTHROPIC-KEY'] }}

--- a/backend/Baca.Api/Endpoints/VoiceEndpoints.cs
+++ b/backend/Baca.Api/Endpoints/VoiceEndpoints.cs
@@ -59,8 +59,19 @@ public static class VoiceEndpoints
             return Results.BadRequest("Transcription is required.");
         }
 
-        var response = await voiceParsingService.ParseTranscriptionAsync(request.Transcription.Trim(), ct);
-        return TypedResults.Ok(response);
+        try
+        {
+            var response = await voiceParsingService.ParseTranscriptionAsync(request.Transcription.Trim(), ct);
+            return TypedResults.Ok(response);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("API key", StringComparison.OrdinalIgnoreCase))
+        {
+            return Results.Problem("AI služba není nakonfigurována. Kontaktujte administrátora.", statusCode: 503);
+        }
+        catch (HttpRequestException)
+        {
+            return Results.Problem("Nepodařilo se spojit s AI službou. Zkuste to později.", statusCode: 502);
+        }
     }
 
     private static async Task<IResult> ParseBulkAsync(
@@ -79,7 +90,18 @@ public static class VoiceEndpoints
             return Results.BadRequest("Text is required.");
         }
 
-        var response = await voiceParsingService.ParseBulkTextAsync(request.Text.Trim(), ct);
-        return TypedResults.Ok(response);
+        try
+        {
+            var response = await voiceParsingService.ParseBulkTextAsync(request.Text.Trim(), ct);
+            return TypedResults.Ok(response);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("API key", StringComparison.OrdinalIgnoreCase))
+        {
+            return Results.Problem("AI služba není nakonfigurována. Kontaktujte administrátora.", statusCode: 503);
+        }
+        catch (HttpRequestException)
+        {
+            return Results.Problem("Nepodařilo se spojit s AI službou. Zkuste to později.", statusCode: 502);
+        }
     }
 }

--- a/frontend/src/components/tasks/CreateTaskPage.tsx
+++ b/frontend/src/components/tasks/CreateTaskPage.tsx
@@ -51,8 +51,9 @@ export default function CreateTaskPage() {
       } else {
         setParsedTasks(result.tasks);
       }
-    } catch {
-      setBulkError('Nepoda\u0159ilo se zpracovat text. Zkuste to znovu.');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '';
+      setBulkError(msg ? `Chyba: ${msg}` : 'Nepodařilo se zpracovat text. Zkuste to znovu.');
     } finally {
       setBulkParsing(false);
     }

--- a/frontend/src/hooks/useVoiceFlow.ts
+++ b/frontend/src/hooks/useVoiceFlow.ts
@@ -65,8 +65,9 @@ export default function useVoiceFlow(): UseVoiceFlowResult {
           const result = await voice.parse({ transcription });
           setParsed(result);
           setFlowState('preview');
-        } catch {
-          setProcessingError('Nepodařilo se zpracovat nahrávku');
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : '';
+          setProcessingError(msg || 'Nepodařilo se zpracovat nahrávku');
           setFlowState('idle');
           recorder.reset();
         } finally {


### PR DESCRIPTION
## Summary
- **Cold starts**: Set `--min-replicas 1` for both `baca-api` and `baca-web` so containers stay warm
- **Anthropic key**: Updated secret reference from `ANTHROPHICAPI` to `ANTHROPIC-KEY` (renamed in GitHub)
- **Error messages**: Voice/bulk-import endpoints now catch missing API key (503) and HTTP failures (502), returning Czech error messages. Frontend surfaces the actual error instead of a generic fallback.

## Test plan
- [ ] After deploy, first page load should be fast (no cold start)
- [ ] Bulk import should either work (if key is set) or show "AI služba není nakonfigurována"
- [ ] Voice recording errors should show meaningful messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)