### PR TITLE
[v0.5.0] version, eslint fix, build-time version display

### DIFF
--- a/backend/Baca.Api/Baca.Api.csproj
+++ b/backend/Baca.Api/Baca.Api.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <PropertyGroup>
+    <Version>0.5.0</Version>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- EF Core + PostgreSQL -->
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.*" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "0.5.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -2067,6 +2067,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -32,7 +32,7 @@ export default function Header() {
           <Link to="/" className="text-xl font-bold flex items-center space-x-2">
             <span className="bg-white text-forest-800 w-8 h-8 rounded flex items-center justify-center">B</span>
             <span className="hidden sm:inline">{DEFAULT_APP_NAME}</span>
-            <span className="text-[10px] text-green-300 font-normal ml-1 hidden sm:inline">v0.5.0</span>
+            <span className="text-[10px] text-green-300 font-normal ml-1 hidden sm:inline">v{__APP_VERSION__}</span>
           </Link>
 
           <nav className="hidden md:flex items-center space-x-4">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -32,6 +32,7 @@ export default function Header() {
           <Link to="/" className="text-xl font-bold flex items-center space-x-2">
             <span className="bg-white text-forest-800 w-8 h-8 rounded flex items-center justify-center">B</span>
             <span className="hidden sm:inline">{DEFAULT_APP_NAME}</span>
+            <span className="text-[10px] text-green-300 font-normal ml-1 hidden sm:inline">v0.5.0</span>
           </Link>
 
           <nav className="hidden md:flex items-center space-x-4">

--- a/frontend/src/components/tasks/QuickTaskInput.tsx
+++ b/frontend/src/components/tasks/QuickTaskInput.tsx
@@ -2,18 +2,10 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { tasks as tasksApi, voice } from '@/api/client';
 import { useQuickTaskDefaults } from '@/hooks/useQuickTaskDefaults';
 import useVoiceRecorder from '@/hooks/useVoiceRecorder';
+import { isConfirmWord } from '@/utils/confirmWords';
 
 interface QuickTaskInputProps {
   onTaskCreated: () => void;
-}
-
-const CONFIRM_WORDS = new Set([
-  'jo', 'ano', 'ok', 'okay', 'hotovo', 'yes', 'jasně', 'jasne', 'správně', 'spravne', 'tak',
-]);
-
-export function isConfirmWord(text: string): boolean {
-  const normalized = text.trim().toLowerCase();
-  return normalized.length > 0 && CONFIRM_WORDS.has(normalized);
 }
 
 type VoicePhase = 'idle' | 'recording' | 'transcribing' | 'confirm';

--- a/frontend/src/components/tasks/__tests__/QuickTaskInput.test.tsx
+++ b/frontend/src/components/tasks/__tests__/QuickTaskInput.test.tsx
@@ -109,7 +109,7 @@ describe('QuickTaskInput', () => {
   });
 
   it('exports isConfirmWord that recognizes Czech confirm words', async () => {
-    const { isConfirmWord } = await import('../QuickTaskInput');
+    const { isConfirmWord } = await import('@/utils/confirmWords');
     expect(isConfirmWord('jo')).toBe(true);
     expect(isConfirmWord('ano')).toBe(true);
     expect(isConfirmWord('hotovo')).toBe(true);

--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string;

--- a/frontend/src/utils/confirmWords.ts
+++ b/frontend/src/utils/confirmWords.ts
@@ -1,0 +1,8 @@
+const CONFIRM_WORDS = new Set([
+  'jo', 'ano', 'ok', 'okay', 'hotovo', 'yes', 'jasně', 'jasne', 'správně', 'spravne', 'tak',
+]);
+
+export function isConfirmWord(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  return normalized.length > 0 && CONFIRM_WORDS.has(normalized);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,10 +2,14 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import pkg from './package.json' with { type: 'json' }
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import pkg from './package.json' with { type: 'json' }
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- Version 0.5.0 in `Baca.Api.csproj` and `package.json`
- Fix eslint `react-refresh/only-export-components` — move `isConfirmWord` to `utils/confirmWords.ts`
- Header version derived from `package.json` via Vite `define` (no more hardcoded string)
- `globals.d.ts` type declaration for `__APP_VERSION__`
- Sync `package-lock.json` to 0.5.0

Combines and supersedes closed PRs #59 and #60.

## Test plan
- [x] 200 frontend tests pass
- [x] Frontend build clean
- [x] Backend build clean
- [ ] Verify `v0.5.0` shows in header after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)