### PR TITLE
fix: OIDC callback path mismatch

### DIFF
--- a/backend/Baca.Api/Program.cs
+++ b/backend/Baca.Api/Program.cs
@@ -79,6 +79,7 @@ builder.Services.AddAuthentication(options =>
     options.ResponseType = "code";
     options.UsePkce = true;
     options.SaveTokens = true;
+    options.CallbackPath = "/auth/callback";
 
     options.Scope.Clear();
     options.Scope.Add("openid");


### PR DESCRIPTION
Set CallbackPath to /auth/callback to match registrace client registration. Default /signin-oidc caused ID2043 error.