### PR TITLE
fix: UseForwardedHeaders for OIDC redirect behind Azure proxy

### DIFF
--- a/backend/Baca.Api/Program.cs
+++ b/backend/Baca.Api/Program.cs
@@ -162,6 +162,16 @@ var app = builder.Build();
 await SeedDataAsync(app);
 
 // Middleware
+var forwardedHeadersOptions = new ForwardedHeadersOptions
+{
+    ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor
+        | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto
+        | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost,
+};
+// Azure Container Apps: trust any proxy
+forwardedHeadersOptions.KnownIPNetworks.Clear();
+forwardedHeadersOptions.KnownProxies.Clear();
+app.UseForwardedHeaders(forwardedHeadersOptions);
 app.UseCors();
 app.UseAuthentication();
 app.UseMiddleware<TokenRefreshMiddleware>();


### PR DESCRIPTION
## Summary
OIDC middleware was constructing redirect_uri with the internal container hostname (`http://baca-api.calmwater-...`) instead of `https://baca.ovcina.cz`. 

Adds `UseForwardedHeaders` to respect `X-Forwarded-Host` and `X-Forwarded-Proto` from Azure Container Apps reverse proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)