### PR TITLE
fix: OIDC callback under /api for proxy routing

### DIFF
--- a/backend/Baca.Api/Program.cs
+++ b/backend/Baca.Api/Program.cs
@@ -79,7 +79,7 @@ builder.Services.AddAuthentication(options =>
     options.ResponseType = "code";
     options.UsePkce = true;
     options.SaveTokens = true;
-    options.CallbackPath = "/auth/callback";
+    options.CallbackPath = "/api/auth/callback";
 
     options.Scope.Clear();
     options.Scope.Add("openid");


### PR DESCRIPTION
Callback path /auth/callback hit the frontend container (405). Changed to /api/auth/callback so the proxy routes it to the API.