### PR TITLE
fix: increase nginx proxy buffer for OIDC auth cookies

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,6 +17,12 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Connection "";
+
+        # OIDC auth cookies can be large (access+refresh+id tokens stored via SaveTokens)
+        # Default 4k/8k is too small → nginx returns 502
+        proxy_buffer_size 32k;
+        proxy_buffers 4 32k;
+        proxy_busy_buffers_size 32k;
     }
 
     # SPA fallback — serve index.html for all non-file routes


### PR DESCRIPTION
## Summary
- OIDC `SaveTokens=true` stores access+refresh+id tokens in the auth cookie
- Response headers exceed nginx's default 4-8k `proxy_buffer_size`
- This caused the **502 Bad Gateway** on `/api/auth/callback` after successful login
- Fix: increase `proxy_buffer_size`, `proxy_buffers`, and `proxy_busy_buffers_size` to 32k

## Evidence
- Azure logs confirm the OIDC flow completes (token exchange + OnTokenValidated DB queries succeed)
- The 502 comes from nginx, not from baca-api — classic proxy buffer overflow

## Test plan
- [ ] Deploy baca-web with updated nginx.conf
- [ ] Try login flow: baca.ovcina.cz → registrace → callback → should redirect to / with auth cookie
- [ ] Set registrace back to Production after confirming

🤖 Generated with [Claude Code](https://claude.com/claude-code)